### PR TITLE
Limit library imports to where they are used

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,6 @@ let Discord = require('discord.js')
 let client = new Discord.Client()
 
 // client appends
-client.moment = require('moment')
 client.settings = require('./settings/settings.json')
 client.hd = require('humanize-duration') // huminzes time from seconds
 client.cron = require('node-cron')

--- a/app.js
+++ b/app.js
@@ -27,3 +27,7 @@ cron.schedule('0 0 * * mon', () => {
 
 // init
 client.login(client.settings.token)
+  .catch((error) => {
+    client.log(error)
+    process.exit(1)
+  })

--- a/app.js
+++ b/app.js
@@ -1,9 +1,10 @@
+const cron = require('node-cron')
 let Discord = require('discord.js')
+
 let client = new Discord.Client()
 
 // client appends
 client.settings = require('./settings/settings.json')
-client.cron = require('node-cron')
 client.discord = Discord
 client.fs = require('fs')
 client.jimp = require('jimp')
@@ -20,7 +21,7 @@ require('./library/client_events.js')(client)
 require('./library/database_lib.js')(client)
 
 // weekly wipe at 12 am on monday
-client.cron.schedule('0 0 * * mon', () => {
+cron.schedule('0 0 * * mon', () => {
   client.submitweek()
   client.clearWeekResults()
   client.log('Cleared weekly results')

--- a/app.js
+++ b/app.js
@@ -13,10 +13,19 @@ if (client.settings.dev_mode) {
   client.settings.prefix = client.settings.beta_prefix
 }
 
-// Require client events and functions
 require('./library/client_functions.js')(client)
-require('./library/client_events.js')(client)
+client.log(`Loaded client functions`)
 require('./library/database_lib.js')(client)
+client.log(`Loaded database functions`)
+
+require('./library/client_events.js')(client)
+client.log(`Loaded client events`)
+
+let connect = () => {
+  return new Promise(resolve => {
+    client.connectDB(db => resolve(db))
+  })
+}
 
 // weekly wipe at 12 am on monday
 cron.schedule('0 0 * * mon', () => {
@@ -25,9 +34,14 @@ cron.schedule('0 0 * * mon', () => {
   client.log('Cleared weekly results')
 })
 
-// init
-client.login(client.settings.token)
-  .catch((error) => {
-    client.log(error)
-    process.exit(1)
-  })
+connect().then(db => {
+  client.log(`Connected Database`)
+  require('./library/leaderboard_fetch.js')(client, db)
+  client.log(`loaded leaderboard library`)
+
+  client.login(client.settings.token)
+    .catch((error) => {
+      client.log(error)
+      process.exit(1)
+    })
+})

--- a/app.js
+++ b/app.js
@@ -7,7 +7,6 @@ let client = new Discord.Client()
 client.settings = require('./settings/settings.json')
 client.discord = Discord
 client.fs = require('fs')
-client.jimp = require('jimp')
 
 // check devmode state
 if (client.settings.dev_mode) {

--- a/app.js
+++ b/app.js
@@ -6,7 +6,6 @@ let client = new Discord.Client()
 // client appends
 client.settings = require('./settings/settings.json')
 client.discord = Discord
-client.fs = require('fs')
 
 // check devmode state
 if (client.settings.dev_mode) {

--- a/app.js
+++ b/app.js
@@ -3,7 +3,6 @@ let client = new Discord.Client()
 
 // client appends
 client.settings = require('./settings/settings.json')
-client.hd = require('humanize-duration') // huminzes time from seconds
 client.cron = require('node-cron')
 client.discord = Discord
 client.fs = require('fs')

--- a/commands/general/stats.js
+++ b/commands/general/stats.js
@@ -1,3 +1,4 @@
+const jimp = require('jimp')
 const hd = require('humanize-duration')
 
 module.exports.load = (client) => {
@@ -20,7 +21,7 @@ module.exports.load = (client) => {
         })
 
         // load template
-        await client.jimp.read('./assets/time_card.png')
+        await jimp.read('./assets/time_card.png')
           .then(i => {
             source = i
           })
@@ -34,7 +35,7 @@ module.exports.load = (client) => {
         }
 
         // overlay avatar on template image
-        await client.jimp.read(av)
+        await jimp.read(av)
           .then(i => {
             avatar = i
           })
@@ -42,7 +43,7 @@ module.exports.load = (client) => {
         await source.composite(avatar, 14, 14)
 
         // write the text stuff
-        await client.jimp.loadFont(client.jimp.FONT_SANS_16_WHITE)
+        await jimp.loadFont(jimp.FONT_SANS_16_WHITE)
           .then(async font => {
             source.print(font, 245, 25, `${message.author.username}#${message.author.discriminator}`)
             source.print(font, 135, 90, abbreviateTime(res.current_session_playtime))
@@ -51,7 +52,7 @@ module.exports.load = (client) => {
           })
 
         // send the pic as png
-        await source.getBufferAsync(client.jimp.MIME_PNG)
+        await source.getBufferAsync(jimp.MIME_PNG)
           .then(buffer => {
             message.channel.send({
               files: [{

--- a/commands/general/stats.js
+++ b/commands/general/stats.js
@@ -1,3 +1,5 @@
+const hd = require('humanize-duration')
+
 module.exports.load = (client) => {
   client.commands['stats'] = {
     run (message) {
@@ -67,7 +69,7 @@ module.exports.load = (client) => {
           })
 
         function abbreviateTime (playtime) {
-          return client.hd(playtime * 1000, { units: ['h', 'm', 's'], round: true })
+          return hd(playtime * 1000, { units: ['h', 'm', 's'], round: true })
             .replace('hours', 'h')
             .replace('minutes', 'm')
             .replace('seconds', 's')

--- a/library/client_events.js
+++ b/library/client_events.js
@@ -1,3 +1,5 @@
+const moment = require('moment')
+
 module.exports = client => {
   client.on('ready', async () => {
     await client.log('Successfully connected to discord.')
@@ -122,7 +124,7 @@ module.exports = client => {
             // record that they practiced for NaN seconds. This is really bad because adding NaN to their existing time produces more NaNs.
             if (!newMember.selfMute && !newMember.serverMute && oldMember.s_time == null && restwo.permitted_channels.includes(newMember.voiceChannelID)) {
               // if they are unmuted and a start time dosnt exist and they are in a good channel
-              newMember.s_time = client.moment().unix()
+              newMember.s_time = moment().unix()
             } else if (oldMember.s_time != null) {
               // if a start time exist transfer it to new user object
               newMember.s_time = oldMember.s_time
@@ -134,8 +136,9 @@ module.exports = client => {
                 return
               }
 
-              res.current_session_playtime += client.moment().unix() - newMember.s_time
-              res.overall_session_playtime += client.moment().unix() - newMember.s_time
+              const playtime = moment().unix() - newMember.s_time
+              res.current_session_playtime += playtime
+              res.overall_session_playtime += playtime
 
               const hourrole = '529404918885384203'
               // const activerole = '542790691617767424'
@@ -154,7 +157,7 @@ module.exports = client => {
               }
 
               client.writeUserData(newMember.user.id, res, () => {
-                client.log(`User ${newMember.user.username}#${newMember.user.discriminator} practiced for ${client.moment().unix() - newMember.s_time} seconds`)
+                client.log(`User ${newMember.user.username}#${newMember.user.discriminator} practiced for ${playtime} seconds`)
                 newMember.s_time = null
                 oldMember.s_time = null
               })

--- a/library/client_events.js
+++ b/library/client_events.js
@@ -6,11 +6,6 @@ module.exports = client => {
     await client.user.setActivity(client.settings.activity, { type: 'Playing' }).catch(e => client.cannon.fire('Could not set activity.'))
     await client.log(`Successfully set activity to ${client.settings.activity}`)
     await client.loadCommands(() => client.log(`Successfully loaded commands!`))
-    await client.connectDB(db => {
-      client.log(`Connected Database`)
-      require('./leaderboard_fetch.js')(client, db)
-      client.log(`loaded leaderboard library`)
-    })
   })
 
   client.on('message', async message => {

--- a/library/client_functions.js
+++ b/library/client_functions.js
@@ -1,6 +1,8 @@
+const moment = require('moment')
+
 module.exports = client => {
   client.log = (string) => {
-    console.log(`${client.moment().format('MMMM Do YYYY, h:mm:ss a')} :: ${string}`)
+    console.log(`${moment().format('MMMM Do YYYY, h:mm:ss a')} :: ${string}`)
   }
 
   client.commandExist = (message) => {

--- a/library/client_functions.js
+++ b/library/client_functions.js
@@ -1,4 +1,5 @@
 const moment = require('moment')
+const fs = require('fs')
 
 module.exports = client => {
   client.log = (string) => {
@@ -20,7 +21,7 @@ module.exports = client => {
 
   client.loadCommands = (callback) => {
     client.commands = {}
-    client.fs.readdir('./commands/general/', (err, files) => {
+    fs.readdir('./commands/general/', (err, files) => {
       if (err) {
         client.log(`Error loading general commands : ${err}`)
         return
@@ -30,7 +31,7 @@ module.exports = client => {
       })
     })
 
-    client.fs.readdir('./commands/admin/', (err, files) => {
+    fs.readdir('./commands/admin/', (err, files) => {
       if (err) {
         client.log(`Error loading admin commands : ${err}`)
         return

--- a/library/leaderboard_fetch.js
+++ b/library/leaderboard_fetch.js
@@ -1,3 +1,5 @@
+const hd = require('humanize-duration')
+
 module.exports = (client, db) => {
   /**
      * Let me provide some context for this monstrosity of a library entry
@@ -28,7 +30,7 @@ module.exports = (client, db) => {
           msgStr += ``
         } else {
           let user = scoreArray[j].split('|')[0]
-          let time = client.hd(scoreArray[j].split('|')[1] * 1000, { units: ['h', 'm', 's'] })
+          let time = hd(scoreArray[j].split('|')[1] * 1000, { units: ['h', 'm', 's'] })
           if (client.users.get(user)) {
             msgStr += `**${j + 1}. ${client.users.get(user).username}#${client.users.get(user).discriminator}**\n \`${time}\`\n`
           } else {
@@ -66,7 +68,7 @@ module.exports = (client, db) => {
           msgStr += ``
         } else {
           let user = scoreArray[j].split('|')[0]
-          let time = client.hd(scoreArray[j].split('|')[1] * 1000, { units: ['h', 'm', 's'] })
+          let time = hd(scoreArray[j].split('|')[1] * 1000, { units: ['h', 'm', 's'] })
           if (client.users.get(user)) {
             msgStr += `**${j + 1}. ${client.users.get(user).username}#${client.users.get(user).discriminator}**\n \`${time}\`\n`
           } else {


### PR DESCRIPTION
Instead of embedding everything in the `client` object, import libraries local to each module.