### PR TITLE
Allow p!stats to be run for other users

### DIFF
--- a/commands/general/stats.js
+++ b/commands/general/stats.js
@@ -8,21 +8,22 @@ module.exports.load = (client) => {
       let args = message.content.split(' ').splice(1)
       let username
       let discriminator
+      let mem
       let userId
       let av = './assets/default_avatar.jpg'
 
-      if (args.length === 1) {
+      if (args.length >= 1) {
         // fqName: "fully qualified name"
         let fqName = args[0].split('#')
         if (fqName.length === 2) {
           username = fqName[0]
           discriminator = fqName[1]
-          let user = client.guilds.get(message.guild.id).members.find(val => val.user.username === username && val.user.discriminator === discriminator).user
-          if (user != null) {
-            userId = user.id
+          mem = client.guilds.get(message.guild.id).members.find(val => val.user.username === username && val.user.discriminator === discriminator)
+          if (mem != null) {
+            userId = mem.user.id
             // checks if user has pfp because discord dosnt return default pfp url >:C
-            if (user.avatarURL != null) {
-              av = user.avatarURL
+            if (mem.user.avatarURL != null) {
+              av = mem.user.avatarURL
             }
           } else {
             return client.errorMessage(message, `Unable to find user ${args[0]}.`)
@@ -34,6 +35,7 @@ module.exports.load = (client) => {
         username = message.author.username
         discriminator = message.author.discriminator
         userId = message.author.id
+        mem = client.guilds.get(message.guild.id).members.get(userId)
         if (message.author.avatarURL != null) {
           av = message.author.avatarURL
         }
@@ -72,7 +74,6 @@ module.exports.load = (client) => {
         // check if the user is actively pracking and update times live if necessary
         let activeTime = 0
         let guild = await client.loadGuildData(message.guild.id)
-        let mem = client.guilds.get(message.guild.id).members.get(userId)
         // these last two conditions should be equivalent but maybe they were already pracking when the bot came up
         if (mem.voiceChannel != null && guild.permitted_channels.includes(mem.voiceChannel.id) && !mem.mute && mem.s_time != null) {
           activeTime = moment().unix() - mem.s_time

--- a/commands/general/stats.js
+++ b/commands/general/stats.js
@@ -5,19 +5,53 @@ const moment = require('moment')
 module.exports.load = (client) => {
   client.commands['stats'] = {
     run (message) {
-      client.loadUserData(message.author.id, async res => {
+      let args = message.content.split(' ').splice(1)
+      let username
+      let discriminator
+      let userId
+      let av = './assets/default_avatar.jpg'
+
+      if (args.length === 1) {
+        // fqName: "fully qualified name"
+        let fqName = args[0].split('#')
+        if (fqName.length === 2) {
+          username = fqName[0]
+          discriminator = fqName[1]
+          let user = client.guilds.get(message.guild.id).members.find(val => val.user.username === username && val.user.discriminator === discriminator).user
+          if (user != null) {
+            userId = user.id
+            // checks if user has pfp because discord dosnt return default pfp url >:C
+            if (user.avatarURL != null) {
+              av = user.avatarURL
+            }
+          } else {
+            return client.errorMessage(message, `Unable to find user ${args[0]}.`)
+          }
+        } else {
+          return client.errorMessage(message, `Invalid username format.`)
+        }
+      } else {
+        username = message.author.username
+        discriminator = message.author.discriminator
+        userId = message.author.id
+        if (message.author.avatarURL != null) {
+          av = message.author.avatarURL
+        }
+      }
+
+      client.loadUserData(userId, async res => {
         if (res === null) {
           client.errorMessage(message, 'Error fetching your data from our servers, please try again.')
           return
         }
 
-        // set "semi-global" variabls
+        // set "semi-global" variables
         let avatar
         let source
         let poss
 
         // get leaderboard pos
-        await client.fetchWeeklyLeaderboardPos(message, pos => {
+        await client.fetchWeeklyLeaderboardPos(message.guild.id, userId, pos => {
           poss = pos.replace(/`/g, '')
         })
 
@@ -26,14 +60,6 @@ module.exports.load = (client) => {
           .then(i => {
             source = i
           })
-
-        // checks if user has pfp because discord dosnt return default pfp url >:C
-        let av
-        if (message.author.avatarURL == null) {
-          av = './assets/default_avatar.jpg'
-        } else {
-          av = message.author.avatarURL
-        }
 
         // overlay avatar on template image
         await jimp.read(av)
@@ -46,7 +72,7 @@ module.exports.load = (client) => {
         // check if the user is actively pracking and update times live if necessary
         let activeTime = 0
         let guild = await client.loadGuildData(message.guild.id)
-        let mem = client.guilds.get(message.guild.id).members.get(message.author.id)
+        let mem = client.guilds.get(message.guild.id).members.get(userId)
         // these last two conditions should be equivalent but maybe they were already pracking when the bot came up
         if (mem.voiceChannel != null && guild.permitted_channels.includes(mem.voiceChannel.id) && !mem.mute && mem.s_time != null) {
           activeTime = moment().unix() - mem.s_time
@@ -55,7 +81,7 @@ module.exports.load = (client) => {
         // write the text stuff
         await jimp.loadFont(jimp.FONT_SANS_16_WHITE)
           .then(async font => {
-            source.print(font, 245, 25, `${message.author.username}#${message.author.discriminator}`)
+            source.print(font, 245, 25, `${username}#${discriminator}`)
             source.print(font, 135, 90, abbreviateTime(res.current_session_playtime + activeTime))
             source.print(font, 280, 90, abbreviateTime(res.overall_session_playtime + activeTime))
             source.print(font, 435, 90, poss)

--- a/library/leaderboard_fetch.js
+++ b/library/leaderboard_fetch.js
@@ -67,7 +67,7 @@ module.exports = (client, db) => {
           }
         }
 
-        client.fetchOverallLeaderboardPos(message, pos => {
+        client.fetchOverallLeaderboardPos(message.guild.id, message.author.id, pos => {
           msgStr = `**${message.author.username}**, you are rank ${pos}\n ${msgStr}`
           callback(msgStr)
         })
@@ -113,7 +113,7 @@ module.exports = (client, db) => {
         }
 
         if (message != null) {
-          client.fetchWeeklyLeaderboardPos(message, pos => {
+          client.fetchWeeklyLeaderboardPos(message.guild.id, message.author.id, pos => {
             msgStr = `**${message.author.username}**, you are rank ${pos}\n ${msgStr}`
             callback(msgStr)
           })
@@ -124,8 +124,8 @@ module.exports = (client, db) => {
     })
   }
 
-  client.fetchWeeklyLeaderboardPos = (message, callback) => {
-    client.findCurrentPrackers(message.guild.id, (currentPrackers) => {
+  client.fetchWeeklyLeaderboardPos = (guildId, userId, callback) => {
+    client.findCurrentPrackers(guildId, (currentPrackers) => {
       let scoreArray = []
       let msgStr = ''
       db.collection('users').find({}).toArray()
@@ -153,7 +153,7 @@ module.exports = (client, db) => {
         for (let i = 0; i <= scoreArray.length; i++) {
           if (scoreArray[i]) {
             let user = scoreArray[i].split('|')[0]
-            if (user === message.author.id) { pos = trueJ + 1 }
+            if (user === userId) { pos = trueJ + 1 }
             trueJ++
           }
         }
@@ -165,8 +165,8 @@ module.exports = (client, db) => {
     })
   }
 
-  client.fetchOverallLeaderboardPos = (message, callback) => {
-    client.findCurrentPrackers(message.guild.id, (currentPrackers) => {
+  client.fetchOverallLeaderboardPos = (guildId, userId, callback) => {
+    client.findCurrentPrackers(guildId, (currentPrackers) => {
       let scoreArray = []
       let msgStr = ''
       db.collection('users').find({}).toArray()
@@ -194,7 +194,7 @@ module.exports = (client, db) => {
         for (let i = 0; i <= scoreArray.length; i++) {
           if (scoreArray[i]) {
             let user = scoreArray[i].split('|')[0]
-            if (user === message.author.id) { pos = trueJ + 1 }
+            if (user === userId) { pos = trueJ + 1 }
             trueJ++
           }
         }


### PR DESCRIPTION
Allows p!stats to be run for other users. Username is specified as username#discriminator - not as <@id> because that would ping the subject of the query and we don't want the subject getting pinged every time someone inquires about their ptime.

In the process, had to make some of the functions in leaderboard_fetch.js a little more flexible in not automatically returning the leaderboard position of the message sender. The refactor into a practice manager will help to decouple this code a little better.