### PR TITLE
FEATURE: allow users to send messages in #practice-room-chat.

### DIFF
--- a/library/client_events.js
+++ b/library/client_events.js
@@ -122,7 +122,11 @@ module.exports = client => {
               prChan.overwritePermissions(newMember.user, { SEND_MESSAGES: true })
             } else {
               // remove the permission overwrite when member is no longer in a practice room
-              prChan.permissionOverwrites.get(newMember.user.id).delete()
+              let existingOverride = prChan.permissionOverwrites.get(newMember.user.id)
+              // this shouldn't happen unless someone manually deletes the override, but if for some reason it's gone, no big deal, just move on.
+              if (existingOverride != null) {
+                existingOverride.delete()
+              }
             }
 
             // n.b. if this is the first time the bot sees a user, s_time may be undefined but *not* null. Therefore, == (and not ===)

--- a/library/client_events.js
+++ b/library/client_events.js
@@ -1,4 +1,5 @@
 const moment = require('moment')
+const Discord = require('discord.js')
 
 module.exports = client => {
   client.on('error', client.log)
@@ -126,7 +127,7 @@ module.exports = client => {
               let existingOverride = prChan.permissionOverwrites.get(newMember.user.id)
               // existingOverride shouldn't be null unless someone manually deletes the override, but if for some reason it's gone, no big deal, just move on.
               if (existingOverride != null) {
-                if (existingOverride.allowed.bitfield === 0x800 && existingOverride.denied.bitfield === 0) { // the only permission was allow SEND_MESSAGES
+                if (existingOverride.allowed.bitfield === Discord.Permissions.FLAGS.SEND_MESSAGES && existingOverride.denied.bitfield === 0) { // the only permission was allow SEND_MESSAGES
                   existingOverride.delete()
                 } else {
                   prChan.overwritePermissions(newMember.user, { SEND_MESSAGES: null })

--- a/library/client_events.js
+++ b/library/client_events.js
@@ -114,6 +114,17 @@ module.exports = client => {
             client.createGuild(newMember.guild.id)
             client.log('Created new guild.')
           } else {
+            // if in any practice channel, member has rights to speak in practice room chat (can be muted)
+            let prChan = client.channels.find(chan => chan.name === 'practice-room-chat')
+            if (prChan == null) {
+              client.log('Cannot find #practice-room-chat!')
+            } else if (restwo.permitted_channels.includes(newMember.voiceChannelID)) {
+              prChan.overwritePermissions(newMember.user, { SEND_MESSAGES: true })
+            } else {
+              // remove the permission overwrite when member is no longer in a practice room
+              prChan.permissionOverwrites.get(newMember.user.id).delete()
+            }
+
             // n.b. if this is the first time the bot sees a user, s_time may be undefined but *not* null. Therefore, == (and not ===)
             // comparison is critical here. Otherwise, when they finished practicing, we'll try to subtract an undefined value, and we'll
             // record that they practiced for NaN seconds. This is really bad because adding NaN to their existing time produces more NaNs.


### PR DESCRIPTION
Adds a permissions override allowing SEND_MESSAGES in PR chat for each user that
joins a registered PR. Removes that override once the user is no longer in a PR
(does not deny SEND_MESSAGES, so that the default behaviour is customizable by staff).