### PR TITLE
library: Only load .js files as commands

### DIFF
--- a/library/client_functions.js
+++ b/library/client_functions.js
@@ -27,6 +27,9 @@ module.exports = client => {
         return
       }
       files.forEach(file => {
+        if (!file.endsWith('.js')) {
+          return
+        }
         require(`../commands/general/${file}`).load(client)
       })
     })
@@ -37,6 +40,9 @@ module.exports = client => {
         return
       }
       files.forEach(file => {
+        if (!file.endsWith('.js')) {
+          return
+        }
         require(`../commands/admin/${file}`).load(client)
       })
     })


### PR DESCRIPTION
This is helpful for those of us who might use vim to edit command source.