### PR TITLE
app: Set timezone to America/New_York

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,6 +27,8 @@ cron.schedule('0 0 * * mon', () => {
 //  client.submitweek()
   client.clearWeekResults()
   client.log('Cleared weekly results')
+}, {
+  timezone: "America/New_York"
 })
 
 connect('mongodb://localhost:27017/', 'pinano').then(mongoManager => {


### PR DESCRIPTION
Ensure that we always use US Eastern time regardless of where the
bot is running when we reset the practice clock.

Note that node-cron uses its own https://github.com/node-cron/tz-offset
library, which doesn't currently support things like EST5EDT etc.

Fixes #26.